### PR TITLE
File.ctime -> File.mtime

### DIFF
--- a/lib/im_helpers/forex.rb
+++ b/lib/im_helpers/forex.rb
@@ -32,7 +32,7 @@ module ImHelpers
 
     def self.parse(date=Date.today)
       fn=self.filename(date)
-      if !File.exist?(fn) or date > File.ctime(fn).to_date
+      if !File.exist?(fn) or date > File.mtime(fn).to_date
         self.download(date)
         @@parsed=nil
       end


### PR DESCRIPTION
Le `ctime` peut changer sans que le fichier soit modifié :

`stat /tmp/eurofxref-hist.xml`

```
Fichier : « /tmp/eurofxref-hist.xml »
Taille : 5463335     Blocs : 10672      Blocs d'E/S : 4096   fichier
Périphérique : 20h/32d  Inœud : 283276      Liens : 1
Accès : (0644/-rw-r--r--)  UID : (    0/    root)   GID : (    0/    root)
Accès : 2017-06-26 13:08:22.019659485 +0200
Modif. : 2017-06-23 15:55:14.000000000 +0200
Changt : 2017-06-26 13:08:22.015659616 +0200
Créé : -
```
Du coup il manque les taux du 24 et du 25 juin …
