### PR TITLE
Ajout de l'Océanie et l'Asie dans les groupements de territoires.

### DIFF
--- a/lib/im_helpers/territories.rb
+++ b/lib/im_helpers/territories.rb
@@ -102,6 +102,16 @@ module ImHelpers
        "TT", "TC", "VI", "US", "SX"]
     end
 
+    def self.asia
+      ["AF", "AM", "AZ", "BH", "BD", "BT", "BN", "KH", "CN", "CY", "GE", "IN", "ID", "IR", "IQ", "IL", "JP",
+       "JO", "KZ", "KP", "KR", "KW", "KG", "LA", "LB", "MO", "MY", "MV", "MN", "MM", "NP", "OM", "PK", "PS", "PH",
+       "QA", "SA", "SG", "LK", "SY", "TW", "TJ", "TH", "TL", "TR", "TM", "AE", "UZ", "VN", "YE"]
+    end
+    
+    def self.oceania
+      ["AU", "FJ", "KI", "MH", "FM", "NR", "NZ", "PW", "PG", "WS", "SB", "TO", "TV", "UM", "VU"]
+    end
+    
     def self.africa
       ["DZ", "AO", "BW", "BI", "CM", "CV", "CF", "TD", "KM", "YT", "CG", "CD", "BJ", "GQ", "ET", "ER", "DJ", "GA",
        "GM", "GH", "GN", "CI", "KE", "LS", "LR", "LY", "MG", "MW", "ML", "MR", "MU", "MA", "MZ", "NA", "NE", "NG",


### PR DESCRIPTION
Requis pour [Paramétrage territoires de ventes](https://github.com/immateriel/Support-technique/issues/987)