### PR TITLE
feat: replace IP to country database

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ To get rate between CAD and EUR at 2014-04-01 :
     => 0.6561
 
 ### IpToCountry
-Get country from IP using http://software77.net/geo-ip/ database.
+Get country from IP using https://lite.ip2location.com/database/ip-country database.
 
-    > ImHelpers::IpToCountry.search("216.58.204.142")
+First usage, to download data file and generate .dat file
+
+    > ImHelpers::IpToCountry.get("101.198.199.255")
+    => "US"
+
+Then for any further usage you can keep using `.get` or directly call `.search` as such
+
+    > ImHelpers::IpToCountry.search("101.198.199.255")
     => "US"
 
 ### NameExtractor
@@ -48,7 +55,7 @@ Extract semantic from person name string.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/im_helpers/ip_to_country.rb
+++ b/lib/im_helpers/ip_to_country.rb
@@ -66,7 +66,20 @@ module IpToCountry
       end
     end
 
+    def self.data_is_outdated?
+      #making sure that the data is never older than a month (plus a few days to account for an eventual delay from the provider)
+      csv_date = File.mtime( "#{self.default_dir}/IpToCountry.csv").to_date
+      (Date.today - csv_date).to_i > 34
+    end
+
     def self.search(ip)
+      if File.exist?("#{self.default_dir}/IpToCountry.csv")
+        if self.data_is_outdated?
+          self.download
+          self.packing
+        end
+      end
+
       # the binary table file is looked up with each request
       File.open("#{self.default_dir}/packed-ip.dat","rb") do |rfile|
         rfile.seek(0,IO::SEEK_END)

--- a/lib/im_helpers/ip_to_country.rb
+++ b/lib/im_helpers/ip_to_country.rb
@@ -66,15 +66,23 @@ module IpToCountry
       end
     end
 
-    def self.data_is_outdated?
-      #making sure that the data is never older than a month (plus a few days to account for an eventual delay from the provider)
+    def self.csv_is_outdated?
       csv_date = File.mtime( "#{self.default_dir}/IpToCountry.csv").to_date
-      (Date.today - csv_date).to_i > 34
+      (Date.today - csv_date).to_i > 40 # number of days until we consider the CSV file outdated
+    end
+
+    def self.dat_is_outdated?
+      csv_date = File.mtime( "#{self.default_dir}/packed-ip.dat").to_date
+      (Date.today - csv_date).to_i > 30 # number of days between each data regeneration attempt when the CSV is outdated
+    end
+
+    def self.should_refetch_data?
+      self.csv_is_outdated? && self.dat_is_outdated?
     end
 
     def self.search(ip)
       if File.exist?("#{self.default_dir}/IpToCountry.csv")
-        if self.data_is_outdated?
+        if self.should_refetch_data?
           self.download
           self.packing
         end

--- a/lib/im_helpers/ip_to_country.rb
+++ b/lib/im_helpers/ip_to_country.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 # Country detection from IP address
-# http://software77.net/geo-ip/
+# https://lite.ip2location.com/database/ip-country
 module ImHelpers
 module IpToCountry
     @default_dir="/tmp"
@@ -23,9 +23,12 @@ module IpToCountry
     end
 
     def self.download
-      system("wget -q software77.net/geo-ip/?DL=1 -O #{self.default_dir}/IpToCountry.csv.tmp.gz")
-      system("gunzip #{self.default_dir}/IpToCountry.csv.tmp.gz")
-      system("mv #{self.default_dir}/IpToCountry.csv.tmp #{self.default_dir}/IpToCountry.csv")
+      system("wget -q download.ip2location.com/lite/IP2LOCATION-LITE-DB1.CSV.ZIP -O #{self.default_dir}/IpToCountry.zip")
+      system("unzip -qo #{self.default_dir}/IpToCountry.zip -d #{self.default_dir}")
+      system("mv #{self.default_dir}/IP2LOCATION-LITE-DB1.CSV #{self.default_dir}/IpToCountry.csv")
+      system("rm #{self.default_dir}/README_LITE.TXT")
+      system("rm #{self.default_dir}/LICENSE-CC-BY-SA-4.0.TXT")
+      system("rm #{self.default_dir}/IpToCountry.zip")
     end
 
     def self.update
@@ -39,8 +42,8 @@ module IpToCountry
       last_country=nil
       File.open("#{self.default_dir}/packed-ip.dat","wb") do |wfile|
         IO.foreach("#{self.default_dir}/IpToCountry.csv", :encoding => "ISO-8859-1") do |line|
-          next if !(line =~ /^"/ )
-          s,e,d1,d2,co=line.delete!("\"").split(",")
+          next if (!(line =~ /^"/ ) || line =~ /-/)
+          s,e,co=line.delete!("\"").split(",").slice(0,3)
           s,e = s.to_i,e.to_i
           if !last_start
             # initialize with first entry

--- a/spec/ip_to_country_spec.rb
+++ b/spec/ip_to_country_spec.rb
@@ -1,0 +1,26 @@
+require 'im_helpers'
+
+RSpec.describe ImHelpers::IpToCountry do
+  describe 'get ip-country database' do
+    it "should download the file and process it into a DAT file" do
+      ImHelpers::IpToCountry.get('216.58.204.142')
+
+      expect(File).to exist("./ip_to_country_data/IpToCountry.csv")
+      expect(File).to exist("./ip_to_country_data/packed-ip.dat")
+    end
+  end
+
+  describe 'search country by ip' do
+    it "should return the right country for a given IP address" do
+      expect(ImHelpers::IpToCountry.search('102.129.65.255')).to eq('FR')
+      expect(ImHelpers::IpToCountry.search('101.198.199.255')).to eq('US')
+      expect(ImHelpers::IpToCountry.search('2.57.99.255')).to eq('KZ')
+      expect(ImHelpers::IpToCountry.search('14.137.37.255')).to eq('VU')
+      expect(ImHelpers::IpToCountry.search('37.228.128.255')).to eq('SC')
+    end
+
+    it "should raise a RangeError when provided with an invalid IP address" do
+      expect { ImHelpers::IpToCountry.search('1.1.266.2') }.to raise_error(RangeError)
+    end
+  end
+end

--- a/spec/ip_to_country_spec.rb
+++ b/spec/ip_to_country_spec.rb
@@ -1,12 +1,14 @@
 require 'im_helpers'
 
 RSpec.describe ImHelpers::IpToCountry do
+  let!(:default_dir){ ImHelpers::IpToCountry.default_dir }
+
   describe 'get ip-country database' do
     it "should download the file and process it into a DAT file" do
       ImHelpers::IpToCountry.get('216.58.204.142')
 
-      expect(File).to exist("./ip_to_country_data/IpToCountry.csv")
-      expect(File).to exist("./ip_to_country_data/packed-ip.dat")
+      expect(File).to exist("#{default_dir}/IpToCountry.csv")
+      expect(File).to exist("#{default_dir}/packed-ip.dat")
     end
   end
 

--- a/spec/ip_to_country_spec.rb
+++ b/spec/ip_to_country_spec.rb
@@ -1,9 +1,12 @@
 require 'im_helpers'
+require 'fileutils'
+require 'active_support/time'
+
 
 RSpec.describe ImHelpers::IpToCountry do
   let!(:default_dir){ ImHelpers::IpToCountry.default_dir }
 
-  describe 'get ip-country database' do
+  describe 'get IP to country data' do
     it "should download the file and process it into a DAT file" do
       ImHelpers::IpToCountry.get('216.58.204.142')
 
@@ -12,7 +15,18 @@ RSpec.describe ImHelpers::IpToCountry do
     end
   end
 
-  describe 'search country by ip' do
+
+  describe "no outdated CSV data file" do
+    it "should not have a data file older than one month" do
+      FileUtils.touch "#{default_dir}/IpToCountry.csv", :mtime => Time.now - 35.days
+      expect(ImHelpers::IpToCountry.data_is_outdated?).to eq(true)
+
+      ImHelpers::IpToCountry.search('102.129.65.255')
+      expect(ImHelpers::IpToCountry.data_is_outdated?).to eq(false)
+    end
+
+  end
+  describe 'search country by IP' do
     it "should return the right country for a given IP address" do
       expect(ImHelpers::IpToCountry.search('102.129.65.255')).to eq('FR')
       expect(ImHelpers::IpToCountry.search('101.198.199.255')).to eq('US')


### PR DESCRIPTION
software77.net/geo-ip has been shut down for a long time and its database is no longer available, hence these modifications.

I would normally avoid calling an external API or in this case getting an external file in the test, but these tests are also here to ensure that the external Data provider service is available and that the list is updated.

This way we can ensure that the IP to Country feature works with an up-to-date data source and that if the Data provider went to shut down its service the test would fail to warn us. 