### PR TITLE
Use I18n instead of to_ascii from old gem

### DIFF
--- a/im_helpers.gemspec
+++ b/im_helpers.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "htmlentities", '~> 4.3.0'
   spec.add_dependency "html_truncator", "~> 0.4.0"
-  spec.add_dependency "unidecoder"
   spec.add_dependency "unicode", "~> 0.4.0"
   spec.add_dependency "levenshtein-ffi"
   spec.add_dependency "activesupport", ">= 3.2.0"

--- a/lib/im_helpers/ext/helpers/string_helpers.rb
+++ b/lib/im_helpers/ext/helpers/string_helpers.rb
@@ -1,6 +1,5 @@
 # -*- encoding : utf-8 -*-
 require "htmlentities"
-require 'unidecoder'
 
 module ImHelpers
 
@@ -99,7 +98,7 @@ module ImHelpers
 
     def translit
       begin
-        self.to_ascii
+        I18n.transliterate(self)
       rescue
         # if there is a problem, remove chars
         self.to_s.encode("ascii", :invalid => :replace, :undef => :replace, :replace => "")

--- a/lib/im_helpers/name_extractor.rb
+++ b/lib/im_helpers/name_extractor.rb
@@ -1,6 +1,5 @@
 require 'benchmark'
 require 'unicode'
-require 'unidecoder'
 require 'pstore'
 require 'levenshtein'
 require 'csv'
@@ -141,15 +140,15 @@ module ImHelpers
     end
 
     def normalized
-      Unicode.downcase(to_s).to_ascii
+      I18n.transliterate(Unicode.downcase(to_s))
     end
 
     def normalized_firstname
-      Unicode.downcase(firstname).to_ascii
+      I18n.transliterate(Unicode.downcase(firstname))
     end
 
     def normalized_lastname
-      Unicode.downcase(lastname).to_ascii
+      I18n.transliterate(Unicode.downcase(lastname))
     end
 
     def firstname_found?
@@ -217,7 +216,7 @@ module ImHelpers
           if splitted_names.length > 0
             res = splitted_names.map { |nm| NameExtractor.hash_class.get(nm) }.compact.inject(0) { |sum, x| sum + x } / splitted_names.length
             unless res
-              res = splitted_names.map { |nm| NameExtractor.hash_class.get(nm.to_ascii) }.compact.inject(0) { |sum, x| sum + x } / splitted_names.length
+              res = splitted_names.map { |nm| NameExtractor.hash_class.get(I18n.transliterate(nm)) }.compact.inject(0) { |sum, x| sum + x } / splitted_names.length
             end
             if res
               if Unicode.downcase(name) =~ /^-?[a-z]\.?$/ or Unicode.downcase(name) =~ /^dr\.?/

--- a/lib/im_helpers/version.rb
+++ b/lib/im_helpers/version.rb
@@ -1,3 +1,3 @@
 module ImHelpers
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
ref [ce ticket](https://github.com/immateriel/Support-technique/issues/1286)

testé en insérant `I18n.transliterate("Ærøskøbing")` dans les tests :heavy_check_mark:  (par ailleurs i18n est déjà utilisé ailleurs dans cette Gem)