### PR TITLE
Adjust translate method to new i18n method signature

### DIFF
--- a/lib/im_helpers/ext/helpers/string_helpers.rb
+++ b/lib/im_helpers/ext/helpers/string_helpers.rb
@@ -234,7 +234,7 @@ module ImHelpers
   module TranslationHelpers
     def t(args={})
       trkey=self.downcase.translit.gsub(/\./, "")
-      I18n.t trkey, { :default=>self }.merge(args)
+      I18n.t trkey, { default: self }.merge(args)
     end
 
     def routes_t

--- a/lib/im_helpers/ext/helpers/string_helpers.rb
+++ b/lib/im_helpers/ext/helpers/string_helpers.rb
@@ -234,7 +234,7 @@ module ImHelpers
   module TranslationHelpers
     def t(args={})
       trkey=self.downcase.translit.gsub(/\./, "")
-      I18n.t trkey, args, :default=>self
+      I18n.t trkey, { :default=>self }.merge(args)
     end
 
     def routes_t

--- a/lib/im_helpers/version.rb
+++ b/lib/im_helpers/version.rb
@@ -1,3 +1,3 @@
 module ImHelpers
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
After updating I18n from `0.9.5` to `1.10.0`, we get the following error: 

```ruby
> I18n.t trkey, args, :default=>self
=> ArgumentError: wrong number of arguments (given 2, expected 0..1)
```
It comes from this commit https://github.com/ruby-i18n/i18n/commit/5eeaad7fb35f9a30f654e3bdeb6933daa7fd421d which changes the method signature of `translate`, `t` being an alias for it.

To solve this we can merge the optional arguments in a single options hash