### PR TITLE
Fix countries_with_currency_fallback_by_continents by adding antarctic.

### DIFF
--- a/lib/im_helpers/territories.rb
+++ b/lib/im_helpers/territories.rb
@@ -119,6 +119,10 @@ module ImHelpers
        "BF", "ZM", "SS"]
     end
 
+    def self.antarctic
+      ["TF"]
+    end
+
     def self.currencies
       ["USD", "CAD", "GBP", "AUD", "CHF", "DKK", "NOK", "SEK", "KRW", "ZAR", "BRL", "SGD", "MXN", "NZD", "JPY", "EUR"]
     end
@@ -165,7 +169,7 @@ module ImHelpers
     end
 
     def self.countries_with_currency_fallback_by_continents(currency, default_currency="EUR")
-      continents = ["europe", "africa", "asia", "oceania", "north_america", "south_america"]
+      continents = ["europe", "africa", "asia", "oceania", "north_america", "south_america", "antarctic"]
       countries = self.countries_with_currency_fallback(currency, default_currency)
       territories_list = {}
       continents.each do |continent|

--- a/lib/im_helpers/version.rb
+++ b/lib/im_helpers/version.rb
@@ -1,3 +1,3 @@
 module ImHelpers
-  VERSION = "1.3.3"
+  VERSION = "1.3.4"
 end

--- a/spec/territories_spec.rb
+++ b/spec/territories_spec.rb
@@ -95,6 +95,11 @@ describe ImHelpers::Territories do
       expect(rate).not_to eq(nil)
     end
 
+    it "group world countries by continent" do
+      territories_list = ImHelpers::Territories.countries_with_currency_fallback_by_continents("EUR")
+      expect(territories_list.values.flatten.length).to eq(ImHelpers::Territories.world.count)
+    end
+
   end
 
 end


### PR DESCRIPTION
Corrige territoire manquant pour liste World complète par continent en ajoutant l'Antarctique.
Voir https://github.com/immateriel/Support-technique/issues/1469