### PR TITLE
Revert from I18n to Unicoder Gem for transliteration

### DIFF
--- a/im_helpers.gemspec
+++ b/im_helpers.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "htmlentities", '~> 4.3.0'
   spec.add_dependency "html_truncator", "~> 0.4.0"
+  spec.add_dependency "unidecoder"
   spec.add_dependency "unicode", "~> 0.4.0"
   spec.add_dependency "levenshtein-ffi"
   spec.add_dependency "activesupport", ">= 3.2.0"

--- a/lib/im_helpers/ext/helpers/string_helpers.rb
+++ b/lib/im_helpers/ext/helpers/string_helpers.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 require "htmlentities"
+require 'unidecoder'
 
 module ImHelpers
 
@@ -98,7 +99,7 @@ module ImHelpers
 
     def translit
       begin
-        I18n.transliterate(self)
+        self.to_ascii
       rescue
         # if there is a problem, remove chars
         self.to_s.encode("ascii", :invalid => :replace, :undef => :replace, :replace => "")

--- a/lib/im_helpers/name_extractor.rb
+++ b/lib/im_helpers/name_extractor.rb
@@ -1,5 +1,6 @@
 require 'benchmark'
 require 'unicode'
+require 'unidecoder'
 require 'pstore'
 require 'levenshtein'
 require 'csv'
@@ -140,15 +141,15 @@ module ImHelpers
     end
 
     def normalized
-      I18n.transliterate(Unicode.downcase(to_s))
+      Unicode.downcase(to_s).to_ascii
     end
 
     def normalized_firstname
-      I18n.transliterate(Unicode.downcase(firstname))
+      Unicode.downcase(firstname).to_ascii
     end
 
     def normalized_lastname
-      I18n.transliterate(Unicode.downcase(lastname))
+      Unicode.downcase(lastname).to_ascii
     end
 
     def firstname_found?
@@ -216,7 +217,7 @@ module ImHelpers
           if splitted_names.length > 0
             res = splitted_names.map { |nm| NameExtractor.hash_class.get(nm) }.compact.inject(0) { |sum, x| sum + x } / splitted_names.length
             unless res
-              res = splitted_names.map { |nm| NameExtractor.hash_class.get(I18n.transliterate(nm)) }.compact.inject(0) { |sum, x| sum + x } / splitted_names.length
+              res = splitted_names.map { |nm| NameExtractor.hash_class.get(nm.to_ascii) }.compact.inject(0) { |sum, x| sum + x } / splitted_names.length
             end
             if res
               if Unicode.downcase(name) =~ /^-?[a-z]\.?$/ or Unicode.downcase(name) =~ /^dr\.?/

--- a/lib/im_helpers/version.rb
+++ b/lib/im_helpers/version.rb
@@ -1,3 +1,3 @@
 module ImHelpers
-  VERSION = "1.3.4"
+  VERSION = "1.3.5"
 end


### PR DESCRIPTION
I18n does not transliterate Arabic at all, Unicoder does (albeit  not very convicingly)

```
 > "الحج في الحقبة الاستعمارية".to_ascii
 => "lHj fy lHqb@ lst`mry@" 
```

```
> I18n.transliterate("الحج في الحقبة الاستعمارية")
=> "???? ?? ?????? ???????????"
```