### PR TITLE
Fix valeur TVA ebook pour EE, BG et SK.

### DIFF
--- a/config/tax_rates.yml
+++ b/config/tax_rates.yml
@@ -459,6 +459,18 @@
         :tax_rate: 10.0
         :tax_treatment: :special
         :tax_scope: :na
+    :end_at: 2024-12-31
+    -
+      :default:
+        :tax_rate: 24.0
+      :book:
+        :tax_rate: 14.0
+        :tax_treatment: :special
+        :tax_scope: :all
+      :ebook:
+        :tax_rate: 14.0
+        :tax_treatment: :special
+        :tax_scope: :na
   FR:
     -
       :default:
@@ -934,6 +946,18 @@
         :tax_rate: 19.0
         :tax_treatment: :default
         :tax_scope: :na
+    :end_at: 2025-07-31
+    -
+      :default:
+        :tax_rate: 19.0
+      :book:
+        :tax_rate: 11.0
+        :tax_treatment: :special
+        :tax_scope: :all
+      :ebook:
+        :tax_rate: 11.0
+        :tax_treatment: :special
+        :tax_scope: :na
   RU:
     :default:
       :tax_rate: 18.0
@@ -972,12 +996,12 @@
     :default:
       :tax_rate: 23.0
     :book:
-      :tax_rate: 23.0
-      :tax_treatment: :default
+      :tax_rate: 5.0
+      :tax_treatment: :special
       :tax_scope: :all
     :ebook:
-      :tax_rate: 23.0
-      :tax_treatment: :default
+      :tax_rate: 5.0
+      :tax_treatment: :special
       :tax_scope: :na
   SI:
     -

--- a/config/tax_rates.yml
+++ b/config/tax_rates.yml
@@ -273,12 +273,12 @@
       :default:
         :tax_rate: 20.0
       :book:
-        :tax_rate: 0.0
-        :tax_treatment: :exempt
-        :tax_scope: :limited
+        :tax_rate: 9.0
+        :tax_treatment: :special
+        :tax_scope: :all
       :ebook:
-        :tax_rate: 10.0
-        :tax_treatment: :default
+        :tax_rate: 9.0
+        :tax_treatment: :special
         :tax_scope: :na
   HR:
     -
@@ -420,7 +420,7 @@
         :tax_treatment: :special
         :tax_scope: :all
       :ebook:
-        :tax_rate: 10.0
+        :tax_rate: 9.0
         :tax_treatment: :special
         :tax_scope: :na
   FI:
@@ -965,6 +965,18 @@
       :tax_scope: :all
     :ebook:
       :tax_rate: 20.0
+      :tax_treatment: :default
+      :tax_scope: :na
+    :end_at: 2024-12-31
+  -
+    :default:
+      :tax_rate: 23.0
+    :book:
+      :tax_rate: 23.0
+      :tax_treatment: :default
+      :tax_scope: :all
+    :ebook:
+      :tax_rate: 23.0
       :tax_treatment: :default
       :tax_scope: :na
   SI:

--- a/lib/im_helpers/version.rb
+++ b/lib/im_helpers/version.rb
@@ -1,3 +1,3 @@
 module ImHelpers
-  VERSION = "1.3.6"
+  VERSION = "1.3.7"
 end


### PR DESCRIPTION
Correction des taux de TVA pour l'Estonie, la Bulgarie et la Slovaquie pour la déclaration de TVA de Mireille : https://github.com/immateriel/Support-technique/issues/2600#issuecomment-3437496199