### PR TITLE
Fix problème d'indentation dans tax_rates.yml

### DIFF
--- a/config/tax_rates.yml
+++ b/config/tax_rates.yml
@@ -459,7 +459,7 @@
         :tax_rate: 10.0
         :tax_treatment: :special
         :tax_scope: :na
-    :end_at: 2024-12-31
+      :end_at: 2024-12-31
     -
       :default:
         :tax_rate: 24.0
@@ -946,7 +946,7 @@
         :tax_rate: 19.0
         :tax_treatment: :default
         :tax_scope: :na
-    :end_at: 2025-07-31
+      :end_at: 2025-07-31
     -
       :default:
         :tax_rate: 19.0
@@ -981,28 +981,29 @@
       :tax_treatment: :special
       :tax_scope: :unknown
   SK:
-    :default:
-      :tax_rate: 20.0
-    :book:
-      :tax_rate: 10.0
-      :tax_treatment: :special
-      :tax_scope: :all
-    :ebook:
-      :tax_rate: 20.0
-      :tax_treatment: :default
-      :tax_scope: :na
-    :end_at: 2024-12-31
-  -
-    :default:
-      :tax_rate: 23.0
-    :book:
-      :tax_rate: 5.0
-      :tax_treatment: :special
-      :tax_scope: :all
-    :ebook:
-      :tax_rate: 5.0
-      :tax_treatment: :special
-      :tax_scope: :na
+    -
+      :default:
+        :tax_rate: 20.0
+      :book:
+        :tax_rate: 10.0
+        :tax_treatment: :special
+        :tax_scope: :all
+      :ebook:
+        :tax_rate: 20.0
+        :tax_treatment: :default
+        :tax_scope: :na
+      :end_at: 2024-12-31
+    -
+      :default:
+        :tax_rate: 23.0
+      :book:
+        :tax_rate: 5.0
+        :tax_treatment: :special
+        :tax_scope: :all
+      :ebook:
+        :tax_rate: 5.0
+        :tax_treatment: :special
+        :tax_scope: :na
   SI:
     -
       :default:

--- a/lib/im_helpers/version.rb
+++ b/lib/im_helpers/version.rb
@@ -1,3 +1,3 @@
 module ImHelpers
-  VERSION = "1.3.7"
+  VERSION = "1.3.8"
 end


### PR DESCRIPTION
L'erreur Rails au déploiement n'a pas aidé à trouver le souci :
>  Could not spawn process for application /app: The application encountered the following error: uninitialized constant String::Unicode (NameError)

La correction de l'indentation règle le problème de chargement des fichiers de la gem.