### PR TITLE
Remove escape sphinx query method

### DIFF
--- a/lib/im_helpers/ext/helpers/string_helpers.rb
+++ b/lib/im_helpers/ext/helpers/string_helpers.rb
@@ -6,16 +6,6 @@ module ImHelpers
   module StringMethods
     PARTICLES = %w{d de des du l la le les von}
 
-    def escape_sphinx_query
-      key_value_pairs = [[/@/, '\@'], [/~/, '\~'], [/\//, '\/'], [/\s([-])+\s*/, ' \-'], [/\!/, '\!'], [/\?/, '\?'], [/\(/, '\('], [/\)/, '\)'], [/\"/, '\"'], [/\'/, '\'']]
-      regexp_fragments = key_value_pairs.collect { |k,v| k }
-      self.gsub!(Regexp.union(*regexp_fragments)) do |match|
-        key_value_pairs.detect{|k,v| k =~ match}[1]
-      end
-      self.delete!('"') if self.count('"') % 2 != 0
-      return self
-    end
-
     def strip_spaces
       gsub(/\s+/, " ")
     end

--- a/lib/im_helpers/version.rb
+++ b/lib/im_helpers/version.rb
@@ -1,3 +1,3 @@
 module ImHelpers
-  VERSION = "1.3.9"
+  VERSION = "1.3.10"
 end

--- a/spec/im_helpers_spec.rb
+++ b/spec/im_helpers_spec.rb
@@ -7,15 +7,6 @@ require 'countries'
 
 describe ImHelpers do
   describe "extensions" do
-    it "escapes exclamations points" do
-      expect("Ce qui se passe à Vegas reste à Vegas!".escape_sphinx_query).to eq("Ce qui se passe à Vegas reste à Vegas\\!")
-      expect("Coucou !".escape_sphinx_query).to eq("Coucou \\!")
-    end
-
-    it "escapes at characters" do
-      expect("jean@dupont.com".escape_sphinx_query).to eq("jean\\@dupont.com")
-    end
-
     it "strips html" do
       expect("<p><em>Hello</em> <strong>World</strong></p>".strip_html).to eq("Hello World")
     end


### PR DESCRIPTION
Méthode utilisée seulement dans 7Switch, on la déplace dans le projet directement.

Cf. https://github.com/immateriel/sevenswitch/pull/872, ou la méthode est déplacée